### PR TITLE
Fix(incar): fix the `hse-symmetry-incompatible` rule for `ISYM` default case

### DIFF
--- a/src/vaspin/incar/rules.py
+++ b/src/vaspin/incar/rules.py
@@ -157,6 +157,8 @@ def hse_sym(incar: Incar) -> bool:
     """Checks if symmetry is set right when using hybrid functionals"""
     hybrid = incar.get("LHFCALC", False)
     isym = incar.get("ISYM", None)
+    if isym is None:
+        return True
     return hybrid and isym not in [-1, 0, 3]
 
 


### PR DESCRIPTION
Close #13 . A band-aid solution, we need a more robust way to hand the default value.